### PR TITLE
Encode to JSON the inline results

### DIFF
--- a/telegram.lua
+++ b/telegram.lua
@@ -373,7 +373,7 @@ function telegram:answerInlineQuery(inline_query_id, results, options)
 
 	options = options or {}
 	options.inline_query_id = inline_query_id
-	options.results = results
+	options.results = turbo.escape.json_encode(results)
 	
 	return self:request("answerInlineQuery", options)
 end


### PR DESCRIPTION
answerInlineQuery needs a JSON-serialized array of results.
